### PR TITLE
CO-234 initial versions and setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .idea
+
+charts/logging-client/charts
+charts/logging-client/requirements.lock
+charts/logging-client/logging-client-*.tgz

--- a/charts/logging-client/requirements.yaml
+++ b/charts/logging-client/requirements.yaml
@@ -1,7 +1,15 @@
+#
+# NOTE: until helm issue 3947 is fixed, our chart version numbers are too long to list
+#       to get a full version number for pinning.
+#       e.g. charts.migrations.cnct.io/curator:0.0.6-prod.1+6b9ff26a9f8ee84d0760c68d117cb37677...
+#       (note the dots...)
+#       Using a range for now.
+#       (MLN 4/23/2018)
+#
 depends:
 - name: fluent-bit
   repository: http://charts.migrations.cnct.io
-  version: 0.0.6-0
+  version: ">=0.0.6-prod,<0.0.7-prod"
 - name: eventrouter
   repository: http://charts.migrations.cnct.io
-  version: 0.0.3-0
+  version: ">=0.0.3-prod,<0.0.4-prod"

--- a/charts/logging-client/requirements.yaml
+++ b/charts/logging-client/requirements.yaml
@@ -7,9 +7,9 @@
 #       (MLN 4/23/2018)
 #
 depends:
-- name: fluent-bit
-  repository: http://charts.migrations.cnct.io
-  version: ">=0.0.6-prod,<0.0.7-prod"
-- name: eventrouter
-  repository: http://charts.migrations.cnct.io
-  version: ">=0.0.3-prod,<0.0.4-prod"
+        #- name: fluent-bit
+        #repository: http://charts.migrations.cnct.io
+        #version: ">=0.0.6-prod,<0.0.7-prod"
+        #- name: eventrouter
+        #repository: http://charts.migrations.cnct.io
+        #version: ">=0.0.3-prod,<0.0.4-prod"

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -7,5 +7,4 @@ configs:
     stage: 
       values:
 prod: 
-  doDeploy: none
-  #doDeploy: versionfile
+  doDeploy: versionfile

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,5 +6,9 @@ configs:
       values:
     stage: 
       values:
+helmRepos:
+   - name: cnct-migrations
+     url: http://charts.migrations.cnct.io
 prod: 
-  doDeploy: versionfile
+  doDeploy: none
+  #doDeploy: versionfile

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -6,9 +6,6 @@ configs:
       values:
     stage: 
       values:
-helmRepos:
-   - name: cnct-migrations
-     url: http://charts.migrations.cnct.io
 prod: 
   doDeploy: none
   #doDeploy: versionfile


### PR DESCRIPTION
Make consistent with logging-central.

requirements.lock is not checked in as it is always rebuilt.

version numbers are ranges until helm allows printing of full version numbers.

the required charts are NOT in our new repo yet, so this will not build correctly yet.
this was not hand tested either, due to the charts missing.
The actual major.minor.patch versions are incorrect also...need to fix when we know the real versions.