### PR TITLE
[CO-237] Plumb cluster_uuid though to fluent-bit so that client

### DIFF
--- a/charts/logging-client/values.yaml
+++ b/charts/logging-client/values.yaml
@@ -3,5 +3,6 @@
 fluent-bit:
   name: fluent-bit
   replicaCount: 1
+  cluster_uuid: 00000000-0000-0000-0000-000000000000
   config:
     sink: "stdout"


### PR DESCRIPTION
clusters can indicate who they are when documents are aggregated
by central logging.