### PR TITLE
Remove unused values.

### DIFF
--- a/charts/logging-client/values.yaml
+++ b/charts/logging-client/values.yaml
@@ -1,8 +1,3 @@
-# Default values.
-
 fluent-bit:
   name: fluent-bit
-  replicaCount: 1
   cluster_uuid: 00000000-0000-0000-0000-000000000000
-  config:
-    sink: "stdout"


### PR DESCRIPTION
Values that do nothing (e.g. `replicaCount`) are distracting. Values which are undesirable (e.g. `sink: stdout`) should not be encouraged. Also, the `config:` stanza breaks fluent-bit.